### PR TITLE
"Scr_MakeArrayKey"

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -39,3 +39,6 @@ September 12 2016:
 After a 2 years its still good to write about changes in server code ^^
  - 'SetText' script command now safe to use with dynamically created strings like player names, number increments and etc.
  - 'ClearAllTextAfterHudElem' script command now can be used only in developer mode because of its bugs.
+
+September 13 2016:
+ + Added 'Scr_MakeArrayKey' script and plugin function. It allows you to create script arrays with string keys instead of numeric. Just make sure you passed value returned from 'Scr_AllocString' (call this one on initialization).

--- a/plugins/dlang/cod4x/functions.d
+++ b/plugins/dlang/cod4x/functions.d
@@ -148,6 +148,7 @@ extern (C) void Plugin_Scr_AddUndefined();
 extern (C) void Plugin_Scr_AddVector( vec3_t vec );
 extern (C) void Plugin_Scr_AddArray( );
 extern (C) void Plugin_Scr_MakeArray( );
+extern (C) void Plugin_Scr_MakeArrayKey( int strIdx );
 extern (C) short Plugin_Scr_ExecEntThread( gentity_t* ent, int callbackHook, int numArgs);
 extern (C) short Plugin_Scr_ExecThread( int callbackHook, int numArgs);
 extern (C) void Plugin_Scr_FreeThread( short threadId);

--- a/plugins/function_declarations.h
+++ b/plugins/function_declarations.h
@@ -255,6 +255,7 @@
     __cdecl void Plugin_Scr_AddVector( vec3_t vec );
     __cdecl void Plugin_Scr_AddArray( void );
     __cdecl void Plugin_Scr_MakeArray( void );
+    __cdecl void Plugin_Scr_MakeArrayKey( int strIdx );
     __cdecl short Plugin_Scr_ExecEntThread( gentity_t* ent, int callbackHook, unsigned int numArgs);
     __cdecl short Plugin_Scr_ExecThread( int callbackHook, unsigned int numArgs);
     __cdecl void Plugin_Scr_FreeThread( short threadId);

--- a/src/pluginexports.asm
+++ b/src/pluginexports.asm
@@ -151,6 +151,7 @@ pexport Scr_AddUndefined
 pexport Scr_AddVector
 pexport Scr_AddArray
 pexport Scr_MakeArray
+pexport Scr_MakeArrayKey
 pexport Scr_ExecEntThread
 pexport Scr_ExecThread
 pexport Scr_FreeThread

--- a/src/scr_vm.h
+++ b/src/scr_vm.h
@@ -440,6 +440,7 @@ void __cdecl Scr_AddUndefined(void);
 void __cdecl Scr_AddVector( vec3_t vec );
 void __cdecl Scr_AddArray( void );
 void __cdecl Scr_MakeArray( void );
+void __cdecl Scr_MakeArrayKey( int strIdx );
 void __cdecl Scr_Notify( gentity_t*, unsigned short, unsigned int);
 void __cdecl Scr_NotifyNum( int, unsigned int, unsigned int, unsigned int);
 /*Not working :(  */

--- a/src/scr_vm_hooks.asm
+++ b/src/scr_vm_hooks.asm
@@ -142,6 +142,10 @@ global Scr_MakeArray
 Scr_MakeArray:
 	jmp dword [oScr_MakeArray]
 
+global Scr_MakeArrayKey
+Scr_MakeArrayKey:
+	jmp dword [oScr_MakeArrayKey]
+
 ;global Scr_Notify
 ;Scr_Notify:
 ;	jmp dword [oScr_Notify]
@@ -313,6 +317,7 @@ oScr_AddUndefined dd 0x815eea2
 oScr_AddVector dd 0x815ee12
 oScr_AddArray dd 0x815d5c0
 oScr_MakeArray dd 0x815ed8a
+oScr_MakeArrayKey dd 0x0815D0B8
 oScr_Notify dd 0x80c7604
 oScr_NotifyNum dd 0x815e762
 oScr_PrintPrevCodePos dd 0x814ef6e

--- a/src/version_build.h
+++ b/src/version_build.h
@@ -1,1 +1,1 @@
-#define BUILD_NUMBER 1467
+#define BUILD_NUMBER 1468


### PR DESCRIPTION
Now we able to create string based keys for script arrays.
Usage:
======= initialization ==============
`int testKeyIdx = Scr_AllocString("testKey");`

======== code ==================
```
Scr_MakeArray(); // Creates array.
Scr_AddInt(0); // Adds integer 0 to stack.
Scr_MakeArrayKey(testKeyIdx); // Return script value now 'array' with one key "testKey".
```

=========== script ===================
```
// Value accessible by next way:
arr = someScriptFunction();
iprintln(arr["testKey"]); // Prints 0, key non case sensitive?
```