### PR TITLE
Makefiles

### DIFF
--- a/makefile
+++ b/makefile
@@ -3,6 +3,7 @@ CLIBS=-I..\lib_tomcrypt\headers -I..\lib_tomcrypt\math\tommath
 CFLAGS=-m32 -Wall -O0 -g -fno-omit-frame-pointer -c
 WIN_LFLAGS=-m32 -g -Wl,--nxcompat,--image-base,0x8040000,--stack,0x800000 -Tlinkerscript_win32.ld -mwindows
 WIN_LLIBS=-Llib\ -ltomcrypt_win32 -lmbedtls_win32 -lm -lws2_32 -lwsock32 -liphlpapi -lgdi32 -mwindows -lwinmm -static-libgcc -static -lstdc++
+LINUX_LFLAGS=-m32 -static-libgcc -rdynamic -Tlinkerscript.ld
 LINUX_LLIBS=-L./lib -lmbedtls -lmbedcrypto -lmbedx509 -ltomcrypt_linux -ldl -lpthread -lm -lstdc++ -Wl,-rpath=./
 NASM=nasm
 COD4XBIN=cod4x18_dedrun
@@ -10,64 +11,64 @@ COD4XBIN=cod4x18_dedrun
 all:
 	@echo Please select 'makefile.*' instead of this one.
 
-updateable_exe: windows zlib_win nasm common_updateable_win $(COD4XBIN).exe pexports clean_win
-	@echo Updateable Windows PE compiled successfully.
+updateable_exe: windows zlib_win nasm_win common_updateable_win $(COD4XBIN).exe pexports clean_win
+	@echo [Windows] Updateable PE built successfully.
 
-exe: windows zlib_win nasm common_win $(COD4XBIN).exe pexports clean_win
-	@echo Developer Windows PE build compiled successfully.
+exe: windows zlib_win nasm_win common_win $(COD4XBIN).exe pexports clean_win
+	@echo [Windows] Developer PE built successfully.
 
-updateable_elf: linux zlib_linux nasm common_updateable_linux $(COD4XBIN).elf clean_linux
-	@echo Updateable Linux ELF compiled successfully.
+updateable_elf: linux zlib_linux nasm_linux common_updateable_linux $(COD4XBIN).elf clean_linux
+	@echo [Linux] Updateable ELF built successfully.
 
-elf: linux zlib_linux nasm common_linux $(COD4XBIN).elf clean_linux
-	@echo Developer Linux ELF build compiled successfully.
+elf: linux zlib_linux nasm_linux common_linux $(COD4XBIN).elf clean_linux
+	@echo [Linux] Developer ELF built successfully.
 
 windows:
-	@echo Compiling Windows-specific files...
+	@echo [Windows] Building specific files...
 	@cd bin
 	$(CC) $(CFLAGS) -D WINVER=0x501 -march=nocona $(CLIBS) ..\src\win32\*.c
 	@cd ..
 
 linux:
-	@echo Compiling Linux-specific files...
+	@echo [Linux] Building specific files...
 	cd bin && \
 	$(CC) $(CFLAGS) -D _GNU_SOURCE -mtune=nocona $(CLIBS) ../src/unix/sys_unix.c ../src/unix/sys_linux.c ../src/unix/elf32_parser.c ../src/unix/sys_cod4linker_linux.c ../src/unix/sys_con_tty.c
 
 common_win: 
-	@echo Compiling common...
+	@echo [Windows] Building common code...
 	@cd bin
 	$(CC) $(CFLAGS) -D COD4X18UPDATE -D WINVER=0x501 -march=nocona ..\src\*.c
 	@cd ..
 
 common_linux: 
-	@echo Compiling common...
+	@echo [Linux] Building common code...
 	cd bin && \
 	$(CC) $(CFLAGS) -D COD4X18UPDATE -D _GNU_SOURCE -march=nocona ../src/*.c
 
 common_updateable_win:
-	@echo Compiling common...
+	@echo [Windows] Building self-updateable common code...
 	@cd bin
 	$(CC) $(CFLAGS) -D COD4X18UPDATE -D OFFICIAL -D WINVER=0x501 -march=nocona ..\src\*.c
 	@cd ..
 
 common_updateable_linux:
-	@echo Compiling common...
+	@echo [Linux] Building self-updateable common code...
 	cd bin && \
 	$(CC) $(CFLAGS) -D COD4X18UPDATE -D OFFICIAL -D _GNU_SOURCE -march=nocona ../src/*.c
 
 zlib_win:
-	@echo Compiling ZLib...
+	@echo [Windows] Building ZLib...
 	@cd bin
 	$(CC) $(CFLAGS) -D WINVER=0x501 -mtune=nocona ..\src\zlib\*.c
 	@cd ..
 
 zlib_linux:
-	@echo Compiling ZLib...
+	@echo [Linux] Building ZLib...
 	cd bin && \
 	$(CC) $(CFLAGS) -D _GNU_SOURCE -mtune=nocona ../src/zlib/*.c
 
-nasm:
-	@echo Compiling NASM...
+nasm_win:
+	@echo [Windows] Building NASM code...
 	$(NASM) -f coff src/qcommon_hooks.asm         --prefix _ -o bin/qcommon_hooks.o
 	$(NASM) -f coff src/cmd_hooks.asm             --prefix _ -o bin/cmd_hooks.o
 	$(NASM) -f coff src/filesystem_hooks.asm      --prefix _ -o bin/filesystem_hooks.o
@@ -80,26 +81,42 @@ nasm:
 	$(NASM) -f coff src/msg_hooks.asm             --prefix _ -o bin/msg_hooks.o
 	$(NASM) -f coff src/pluginexports.asm -dWin32 --prefix _ -o bin/pluginexports.o
 
+nasm_linux:
+	@echo [Linux] Building NASM code...
+	$(NASM) -f elf src/qcommon_hooks.asm    -o bin/qcommon_hooks.o
+	$(NASM) -f elf src/cmd_hooks.asm        -o bin/cmd_hooks.o
+	$(NASM) -f elf src/filesystem_hooks.asm -o bin/filesystem_hooks.o
+	$(NASM) -f elf src/misc_hooks.asm       -o bin/misc_hooks.o
+	$(NASM) -f elf src/g_sv_hooks.asm       -o bin/g_sv_hooks.o
+	$(NASM) -f elf src/xassets_hooks.asm    -o bin/xassets_hooks.o
+	$(NASM) -f elf src/trace_hooks.asm      -o bin/trace_hooks.o
+	$(NASM) -f elf src/scr_vm_hooks.asm     -o bin/scr_vm_hooks.o	
+	$(NASM) -f elf src/server_hooks.asm     -o bin/server_hooks.o
+	$(NASM) -f elf src/msg_hooks.asm        -o bin/msg_hooks.o
+	$(NASM) -f elf src/pluginexports.asm    -o bin/pluginexports.o
+
 $(COD4XBIN).exe:
-	@echo Linking binary...
+	@echo [Windows] Linking binary...
 	$(CC) $(WIN_LFLAGS) -o bin\$@ bin\*.o src\win32\win_cod4.res $(WIN_LLIBS)
 
 $(COD4XBIN).elf:
-	@echo Linking binary...
-	$(CC) -m32 -rdynamic -Tlinkerscript.ld -o bin/$(COD4XBIN) bin/*.o $(LINUX_LLIBS)
+	@echo [Linux] Linking binary...
+	$(CC) $(LINUX_LFLAGS) -o bin/$(COD4XBIN) bin/*.o $(LINUX_LLIBS)
+
 
 pexports:
-	@echo Creating plugin export lib...
+	@echo [Windows] Building plugin exports library...
 	@cd bin
 	pexports $(COD4XBIN).exe > $(COD4XBIN).def
 	dlltool -D $(COD4XBIN).exe -d $(COD4XBIN).def -l ..\plugins\libcom_plugin.a
 	@cd ..
 
 clean_win:
-	@echo Cleaning up...
+	@echo [Windows] Cleaning up...
 	@cd bin
 	del *.o
 	@cd ..
 
 clean_linux:
-	@rm src\*.o
+	@echo [Linux] Cleaning up...
+	@rm bin/*.o

--- a/makefile
+++ b/makefile
@@ -1,45 +1,73 @@
 CC=gcc
-WIN_CLIBS=-I..\lib_tomcrypt\headers -I..\lib_tomcrypt\math\tommath
-WIN_CFLAGS=-m32 -Wall -O0 -g -fno-omit-frame-pointer -D WINVER=0x501 -c
+CLIBS=-I..\lib_tomcrypt\headers -I..\lib_tomcrypt\math\tommath
+CFLAGS=-m32 -Wall -O0 -g -fno-omit-frame-pointer -c
 WIN_LFLAGS=-m32 -g -Wl,--nxcompat,--image-base,0x8040000,--stack,0x800000 -Tlinkerscript_win32.ld -mwindows
 WIN_LLIBS=-Llib\ -ltomcrypt_win32 -lmbedtls_win32 -lm -lws2_32 -lwsock32 -liphlpapi -lgdi32 -mwindows -lwinmm -static-libgcc -static -lstdc++
+LINUX_LLIBS=-L./lib -ltomcrypt_linux -ltommath_linux -lsvsapi_elf -ldl -lpthread -lm -lstdc++ -lsteam_api -Wl,-rpath=./
 NASM=nasm
 COD4XBIN=cod4x18_dedrun
 
 all:
 	@echo Please select 'makefile.*' instead of this one.
 
-updateable_exe: windows zlib nasm common $(COD4XBIN).exe pexports clean_win
+updateable_exe: windows zlib_win nasm common_updateable_win $(COD4XBIN).exe pexports clean_win
 	@echo Updateable Windows PE compiled successfully.
 
-exe: windows zlib nasm common_updateable $(COD4XBIN).exe pexports clean_win
+exe: windows zlib_win nasm common_win $(COD4XBIN).exe pexports clean_win
 	@echo Developer Windows PE build compiled successfully.
+
+updateable_elf: linux zlib_linux nasm common_updateable_linux $(COD4XBIN).elf clean_linux
+	@echo Updateable Linux ELF compiled successfully.
+
+elf: linux zlib_linux nasm common_linux $(COD4XBIN).elf clean_linux
+	@echo Developer Linux ELF build compiled successfully.
 
 windows:
 	@echo Compiling Windows-specific files...
 	@cd bin
-	$(CC) $(WIN_CFLAGS) -march=nocona $(WIN_CLIBS) ..\src\win32\sys_win32.c
-	$(CC) $(WIN_CFLAGS) -march=nocona $(WIN_CLIBS) ..\src\win32\win_syscon.c
-	$(CC) $(WIN_CFLAGS) -march=nocona $(WIN_CLIBS) ..\src\win32\sys_cod4linker_win32.c
-	$(CC) $(WIN_CFLAGS) -march=nocona $(WIN_CLIBS) ..\src\win32\pe32_parser.c
+	$(CC) $(CFLAGS) -D WINVER=0x501 -march=nocona $(CLIBS) ..\src\win32\*.c
 	@cd ..
 
-common: 
+linux:
+	@echo Compiling Linux-specific files...
+	@cd bin
+	$(CC) $(CFLAGS) -D _GNU_SOURCE -mtune=nocona $(CLIBS) ../src/unix/*.c
+	@cd ..
+
+common_win: 
 	@echo Compiling common...
 	@cd bin
-	$(CC) $(WIN_CFLAGS) -march=nocona -D COD4X18UPDATE ..\src\*.c
+	$(CC) $(CFLAGS) -D COD4X18UPDATE -D WINVER=0x501 -march=nocona ..\src\*.c
 	@cd ..
 
-common_updateable:
+common_linux: 
 	@echo Compiling common...
 	@cd bin
-	$(CC) $(WIN_CFLAGS) -march=nocona -D COD4X18UPDATE -D OFFICIAL ..\src\*.c
+	$(CC) $(CFLAGS) -D COD4X18UPDATE -D _GNU_SOURCE -march=nocona ../src/*.c
 	@cd ..
 
-zlib:
+common_updateable_win:
+	@echo Compiling common...
+	@cd bin
+	$(CC) $(CFLAGS) -D COD4X18UPDATE -D OFFICIAL -D WINVER=0x501 -march=nocona ..\src\*.c
+	@cd ..
+
+common_updateable_linux:
+	@echo Compiling common...
+	@cd bin
+	$(CC) $(CFLAGS) -D COD4X18UPDATE -D OFFICIAL -D _GNU_SOURCE -march=nocona ../src/*.c
+	@cd ..
+
+zlib_win:
 	@echo Compiling ZLib...
 	@cd bin
-	$(CC) $(WIN_CFLAGS) -mtune=nocona ..\src\zlib\*.c
+	$(CC) $(CFLAGS) -D WINVER=0x501 -mtune=nocona ..\src\zlib\*.c
+	@cd ..
+
+zlib_linux:
+	@echo Compiling ZLib...
+	@cd bin
+	$(CC) $(CFLAGS) -D _GNU_SOURCE -mtune=nocona ../src/zlib/*.c
 	@cd ..
 
 nasm:
@@ -60,6 +88,10 @@ $(COD4XBIN).exe:
 	@echo Linking binary...
 	$(CC) $(WIN_LFLAGS) -o bin\$@ bin\*.o src\win32\win_cod4.res $(WIN_LLIBS)
 
+$(COD4XBIN).elf:
+	@echo Linking binary...
+	$(CC) -m32 -rdynamic -Tlinkerscript.ld -o bin/$(COD4XBIN) bin/*.o $(LINUX_LLIBS)
+
 pexports:
 	@echo Creating plugin export lib...
 	@cd bin
@@ -73,5 +105,5 @@ clean_win:
 	del *.o
 	@cd ..
 
-clean_unix:
+clean_linux:
 	@rm src\*.o

--- a/makefile
+++ b/makefile
@@ -3,18 +3,16 @@ WIN_CLIBS=-I..\lib_tomcrypt\headers -I..\lib_tomcrypt\math\tommath
 WIN_CFLAGS=-m32 -Wall -O0 -g -fno-omit-frame-pointer -D WINVER=0x501 -c
 WIN_LFLAGS=-m32 -g -Wl,--nxcompat,--image-base,0x8040000,--stack,0x800000 -Tlinkerscript_win32.ld -mwindows
 WIN_LLIBS=-Llib\ -ltomcrypt_win32 -lmbedtls_win32 -lm -lws2_32 -lwsock32 -liphlpapi -lgdi32 -mwindows -lwinmm -static-libgcc -static -lstdc++
-
 NASM=nasm
-
 COD4XBIN=cod4x18_dedrun
 
 all:
 	@echo Please select 'makefile.*' instead of this one.
 
-exe: windows zlib nasm common $(COD4XBIN).exe clean_win
+updateable_exe: windows zlib nasm common $(COD4XBIN).exe pexports clean_win
 	@echo Updateable Windows PE compiled successfully.
 
-updateable_exe: windows zlib nasm common_official $(COD4XBIN).exe clean_win
+exe: windows zlib nasm common_updateable $(COD4XBIN).exe pexports clean_win
 	@echo Developer Windows PE build compiled successfully.
 
 windows:
@@ -32,7 +30,7 @@ common:
 	$(CC) $(WIN_CFLAGS) -march=nocona -D COD4X18UPDATE ..\src\*.c
 	@cd ..
 
-common_official:
+common_updateable:
 	@echo Compiling common...
 	@cd bin
 	$(CC) $(WIN_CFLAGS) -march=nocona -D COD4X18UPDATE -D OFFICIAL ..\src\*.c
@@ -61,6 +59,13 @@ nasm:
 $(COD4XBIN).exe:
 	@echo Linking binary...
 	$(CC) $(WIN_LFLAGS) -o bin\$@ bin\*.o src\win32\win_cod4.res $(WIN_LLIBS)
+
+pexports:
+	@echo Creating plugin export lib...
+	@cd bin
+	pexports $(COD4XBIN).exe > $(COD4XBIN).def
+	dlltool -D $(COD4XBIN).exe -d $(COD4XBIN).def -l ..\plugins\libcom_plugin.a
+	@cd ..
 
 clean_win:
 	@echo Cleaning up...

--- a/makefile
+++ b/makefile
@@ -3,7 +3,7 @@ CLIBS=-I..\lib_tomcrypt\headers -I..\lib_tomcrypt\math\tommath
 CFLAGS=-m32 -Wall -O0 -g -fno-omit-frame-pointer -c
 WIN_LFLAGS=-m32 -g -Wl,--nxcompat,--image-base,0x8040000,--stack,0x800000 -Tlinkerscript_win32.ld -mwindows
 WIN_LLIBS=-Llib\ -ltomcrypt_win32 -lmbedtls_win32 -lm -lws2_32 -lwsock32 -liphlpapi -lgdi32 -mwindows -lwinmm -static-libgcc -static -lstdc++
-LINUX_LLIBS=-L./lib -ltomcrypt_linux -ltommath_linux -lsvsapi_elf -ldl -lpthread -lm -lstdc++ -lsteam_api -Wl,-rpath=./
+LINUX_LLIBS=-L./lib -lmbedtls -lmbedcrypto -lmbedx509 -ltomcrypt_linux -ldl -lpthread -lm -lstdc++ -Wl,-rpath=./
 NASM=nasm
 COD4XBIN=cod4x18_dedrun
 
@@ -30,9 +30,8 @@ windows:
 
 linux:
 	@echo Compiling Linux-specific files...
-	@cd bin
-	$(CC) $(CFLAGS) -D _GNU_SOURCE -mtune=nocona $(CLIBS) ../src/unix/*.c
-	@cd ..
+	cd bin && \
+	$(CC) $(CFLAGS) -D _GNU_SOURCE -mtune=nocona $(CLIBS) ../src/unix/sys_unix.c ../src/unix/sys_linux.c ../src/unix/elf32_parser.c ../src/unix/sys_cod4linker_linux.c ../src/unix/sys_con_tty.c
 
 common_win: 
 	@echo Compiling common...
@@ -42,9 +41,8 @@ common_win:
 
 common_linux: 
 	@echo Compiling common...
-	@cd bin
+	cd bin && \
 	$(CC) $(CFLAGS) -D COD4X18UPDATE -D _GNU_SOURCE -march=nocona ../src/*.c
-	@cd ..
 
 common_updateable_win:
 	@echo Compiling common...
@@ -54,9 +52,8 @@ common_updateable_win:
 
 common_updateable_linux:
 	@echo Compiling common...
-	@cd bin
+	cd bin && \
 	$(CC) $(CFLAGS) -D COD4X18UPDATE -D OFFICIAL -D _GNU_SOURCE -march=nocona ../src/*.c
-	@cd ..
 
 zlib_win:
 	@echo Compiling ZLib...
@@ -66,23 +63,22 @@ zlib_win:
 
 zlib_linux:
 	@echo Compiling ZLib...
-	@cd bin
+	cd bin && \
 	$(CC) $(CFLAGS) -D _GNU_SOURCE -mtune=nocona ../src/zlib/*.c
-	@cd ..
 
 nasm:
 	@echo Compiling NASM...
-	$(NASM) -f coff src\qcommon_hooks.asm         --prefix _ -o bin\qcommon_hooks.o
-	$(NASM) -f coff src\cmd_hooks.asm             --prefix _ -o bin\cmd_hooks.o
-	$(NASM) -f coff src\filesystem_hooks.asm      --prefix _ -o bin\filesystem_hooks.o
-	$(NASM) -f coff src\misc_hooks.asm            --prefix _ -o bin\misc_hooks.o
-	$(NASM) -f coff src\g_sv_hooks.asm            --prefix _ -o bin\g_sv_hooks.o
-	$(NASM) -f coff src\xassets_hooks.asm         --prefix _ -o bin\xassets_hooks.o
-	$(NASM) -f coff src\trace_hooks.asm           --prefix _ -o bin\trace_hooks.o
-	$(NASM) -f coff src\scr_vm_hooks.asm          --prefix _ -o bin\scr_vm_hooks.o	
-	$(NASM) -f coff src\server_hooks.asm          --prefix _ -o bin\server_hooks.o
-	$(NASM) -f coff src\msg_hooks.asm             --prefix _ -o bin\msg_hooks.o
-	$(NASM) -f coff src\pluginexports.asm -dWin32 --prefix _ -o bin\pluginexports.o
+	$(NASM) -f coff src/qcommon_hooks.asm         --prefix _ -o bin/qcommon_hooks.o
+	$(NASM) -f coff src/cmd_hooks.asm             --prefix _ -o bin/cmd_hooks.o
+	$(NASM) -f coff src/filesystem_hooks.asm      --prefix _ -o bin/filesystem_hooks.o
+	$(NASM) -f coff src/misc_hooks.asm            --prefix _ -o bin/misc_hooks.o
+	$(NASM) -f coff src/g_sv_hooks.asm            --prefix _ -o bin/g_sv_hooks.o
+	$(NASM) -f coff src/xassets_hooks.asm         --prefix _ -o bin/xassets_hooks.o
+	$(NASM) -f coff src/trace_hooks.asm           --prefix _ -o bin/trace_hooks.o
+	$(NASM) -f coff src/scr_vm_hooks.asm          --prefix _ -o bin/scr_vm_hooks.o	
+	$(NASM) -f coff src/server_hooks.asm          --prefix _ -o bin/server_hooks.o
+	$(NASM) -f coff src/msg_hooks.asm             --prefix _ -o bin/msg_hooks.o
+	$(NASM) -f coff src/pluginexports.asm -dWin32 --prefix _ -o bin/pluginexports.o
 
 $(COD4XBIN).exe:
 	@echo Linking binary...

--- a/makefile
+++ b/makefile
@@ -1,0 +1,72 @@
+CC=gcc
+WIN_CLIBS=-I..\lib_tomcrypt\headers -I..\lib_tomcrypt\math\tommath
+WIN_CFLAGS=-m32 -Wall -O0 -g -fno-omit-frame-pointer -D WINVER=0x501 -c
+WIN_LFLAGS=-m32 -g -Wl,--nxcompat,--image-base,0x8040000,--stack,0x800000 -Tlinkerscript_win32.ld -mwindows
+WIN_LLIBS=-Llib\ -ltomcrypt_win32 -lmbedtls_win32 -lm -lws2_32 -lwsock32 -liphlpapi -lgdi32 -mwindows -lwinmm -static-libgcc -static -lstdc++
+
+NASM=nasm
+
+COD4XBIN=cod4x18_dedrun
+
+all:
+	@echo Please select 'makefile.*' instead of this one.
+
+exe: windows zlib nasm common $(COD4XBIN).exe clean_win
+	@echo Updateable Windows PE compiled successfully.
+
+updateable_exe: windows zlib nasm common_official $(COD4XBIN).exe clean_win
+	@echo Developer Windows PE build compiled successfully.
+
+windows:
+	@echo Compiling Windows-specific files...
+	@cd bin
+	$(CC) $(WIN_CFLAGS) -march=nocona $(WIN_CLIBS) ..\src\win32\sys_win32.c
+	$(CC) $(WIN_CFLAGS) -march=nocona $(WIN_CLIBS) ..\src\win32\win_syscon.c
+	$(CC) $(WIN_CFLAGS) -march=nocona $(WIN_CLIBS) ..\src\win32\sys_cod4linker_win32.c
+	$(CC) $(WIN_CFLAGS) -march=nocona $(WIN_CLIBS) ..\src\win32\pe32_parser.c
+	@cd ..
+
+common: 
+	@echo Compiling common...
+	@cd bin
+	$(CC) $(WIN_CFLAGS) -march=nocona -D COD4X18UPDATE ..\src\*.c
+	@cd ..
+
+common_official:
+	@echo Compiling common...
+	@cd bin
+	$(CC) $(WIN_CFLAGS) -march=nocona -D COD4X18UPDATE -D OFFICIAL ..\src\*.c
+	@cd ..
+
+zlib:
+	@echo Compiling ZLib...
+	@cd bin
+	$(CC) $(WIN_CFLAGS) -mtune=nocona ..\src\zlib\*.c
+	@cd ..
+
+nasm:
+	@echo Compiling NASM...
+	$(NASM) -f coff src\qcommon_hooks.asm         --prefix _ -o bin\qcommon_hooks.o
+	$(NASM) -f coff src\cmd_hooks.asm             --prefix _ -o bin\cmd_hooks.o
+	$(NASM) -f coff src\filesystem_hooks.asm      --prefix _ -o bin\filesystem_hooks.o
+	$(NASM) -f coff src\misc_hooks.asm            --prefix _ -o bin\misc_hooks.o
+	$(NASM) -f coff src\g_sv_hooks.asm            --prefix _ -o bin\g_sv_hooks.o
+	$(NASM) -f coff src\xassets_hooks.asm         --prefix _ -o bin\xassets_hooks.o
+	$(NASM) -f coff src\trace_hooks.asm           --prefix _ -o bin\trace_hooks.o
+	$(NASM) -f coff src\scr_vm_hooks.asm          --prefix _ -o bin\scr_vm_hooks.o	
+	$(NASM) -f coff src\server_hooks.asm          --prefix _ -o bin\server_hooks.o
+	$(NASM) -f coff src\msg_hooks.asm             --prefix _ -o bin\msg_hooks.o
+	$(NASM) -f coff src\pluginexports.asm -dWin32 --prefix _ -o bin\pluginexports.o
+
+$(COD4XBIN).exe:
+	@echo Linking binary...
+	$(CC) $(WIN_LFLAGS) -o bin\$@ bin\*.o src\win32\win_cod4.res $(WIN_LLIBS)
+
+clean_win:
+	@echo Cleaning up...
+	@cd bin
+	del *.o
+	@cd ..
+
+clean_unix:
+	@rm src\*.o

--- a/makefile
+++ b/makefile
@@ -120,3 +120,4 @@ clean_win:
 clean_linux:
 	@echo [Linux] Cleaning up...
 	@rm bin/*.o
+# Travis, are you okay?

--- a/makefile.linux32
+++ b/makefile.linux32
@@ -1,7 +1,7 @@
 all:
 	@echo Building updateable Linux ELF
-	@nmake -s -f makefile updateable_elf
+	@make -s -f makefile updateable_elf
 
 dev:
 	@echo Building developer Linux ELF
-	@nmake -f makefile elf
+	@make -f makefile elf

--- a/makefile.linux32
+++ b/makefile.linux32
@@ -1,0 +1,7 @@
+all:
+	@echo Building updateable Linux ELF
+	@nmake -s -f makefile updateable_elf
+
+dev:
+	@echo Building developer Linux ELF
+	@nmake -f makefile elf

--- a/makefile.linux32
+++ b/makefile.linux32
@@ -1,7 +1,11 @@
 all:
-	@echo Building updateable Linux ELF
-	@make -s -f makefile updateable_elf
+	@echo [Linux] Building updateable ELF...
+	@make -s updateable_elf
 
 dev:
-	@echo Building developer Linux ELF
-	@make -f makefile elf
+	@echo [Linux] Building developer ELF...
+	@make -s elf
+
+dev_verbose:
+	@echo [Linux] Building developer ELF with verbose output...
+	@make elf

--- a/makefile.win32
+++ b/makefile.win32
@@ -1,7 +1,11 @@
 all:
-	@echo Building updateable Windows PE
-	@nmake -s -f makefile updateable_exe
+	@echo [Windows] Building updateable PE...
+	@nmake -s updateable_exe
 
 dev:
-	@echo Building developer Windows PE
-	@nmake -f makefile exe
+	@echo [Windows] Building developer PE...
+	@nmake -s exe
+
+dev_verbose:
+	@echo [Windows] Building developer PE with verbose output...
+	@nmake exe

--- a/makefile.win32
+++ b/makefile.win32
@@ -1,0 +1,7 @@
+all:
+	@echo Building updateable Windows PE
+	@nmake -s -f makefile updateable_exe
+
+dev:
+	@echo Building developer Windows PE
+	@nmake -f makefile exe


### PR DESCRIPTION
Just finished converting *.sh and *.cmd files into makefiles. Please test it working (works for me). Profit: less build files, "all-in-one".
Recipies are: "", "dev", "dev_verbose". "" (empty string) - will compile self-updateable binary file, "dev" will compile non-updateable binary and shouldn't be used for deploy, "dev_verbose" same as "dev" but spams with debug lines used for building.
Current support for Linux and Windows binaries (can't do that for mac).
Examples:
`nmake -f makefile.win32`, `nmake -f makefile.win32 dev`, `nmake -f makefile.win32 dev_verbose`
`make -f makefile.linux32`, `make -f makefile.linux32 dev`, `make -f makefile.linux32 dev_verbose`

=====
Did not touched travis so no idea what's wrong.