### PR TITLE
Pre-ScriptCompile directive

### DIFF
--- a/src/scr_vm.h
+++ b/src/scr_vm.h
@@ -579,6 +579,7 @@ unsigned int Scr_LoadScript(const char* scriptname, PrecacheEntry *precache, int
 qboolean Scr_ExecuteMasterResponse(char* s);
 void Scr_AddStockFunctions();
 void Scr_AddStockMethods();
+void Scr_ScriptPreCompile( void *scr_buffer_handle, char *filepath );
 
 qboolean Scr_AddFunction( const char *cmd_name, xfunction_t function, qboolean developer);
 qboolean Scr_RemoveFunction( const char *cmd_name );
@@ -588,6 +589,7 @@ qboolean Scr_AddMethod( const char *cmd_name, xfunction_t function, qboolean dev
 qboolean Scr_RemoveMethod( const char *cmd_name );
 void Scr_ClearMethods( void );
 __cdecl void* Scr_GetMethod( const char** v_functionName, qboolean* v_developer );
+qboolean Scr_IsSyscallDefined( const char *name );
 void __regparm3 VM_Notify(int, int, VariableValue* val);
 int __cdecl FindEntityId(int, int);
 

--- a/src/scr_vm_cmd.c
+++ b/src/scr_vm_cmd.c
@@ -236,3 +236,29 @@ __cdecl void* Scr_GetMethod( const char** v_functionName, qboolean* v_developer 
 	}
 	return NULL;
 }
+
+/*
+============
+Scr_IsSyscallDefined
+============
+*/
+qboolean Scr_IsSyscallDefined( const char *name )
+{
+	scr_function_t  *cmd;
+	
+	for( cmd = scr_methods; cmd != NULL; cmd = cmd->next )
+	{
+		if( !Q_stricmp( name, cmd->name ) )
+		{
+			return qtrue;
+		}
+	}
+	for( cmd = scr_functions; cmd != NULL; cmd = cmd->next )
+	{
+		if( !Q_stricmp( name, cmd->name ) )
+		{
+			return qtrue;
+		}
+	}
+	return qfalse;
+}

--- a/src/scr_vm_main.c
+++ b/src/scr_vm_main.c
@@ -964,6 +964,8 @@ __cdecl unsigned int Scr_LoadScript(const char *scriptname, PrecacheEntry *preca
             --callScriptStackPtr;
             return 0;
         }
+		
+		Scr_ScriptPreCompile( scr_buffer_handle, filepath );
 
         old_var08 = scrStruct.var_08;
         scrStruct.var_08 = 0;
@@ -1573,4 +1575,122 @@ unsigned int Scr_GetArrayId(unsigned int paramnum, VariableValue** v, int maxvar
     while ( var->hash.u.prevSibling && scrVarGlob_high[var->hash.u.prevSibling].hash.id && i < maxvariables);
 
     return 0;//GetArraySize(ptr);
+}
+
+void Scr_ScriptPreCompile( void *scr_buffer_handle, char *filepath )
+{
+	char * p = strstr( scr_buffer_handle, "#if" );
+	while( p != NULL )
+	{
+		if( *( p - 1 ) == '/' )
+		{
+			p = strstr( p + 1, "#if" );
+			continue;
+		}
+		
+		char * end = strchr( p, '\n' );
+		if( end )
+			*end = '\0';
+
+		Cmd_TokenizeString( p );
+		const char * func = Cmd_Argv( 1 );
+		const char * arg = Cmd_Argv( 2 );
+		
+		qboolean result = qfalse;
+		qboolean negated = qfalse;
+		
+		if( *func == '!' )
+		{
+			++func;
+			negated = qtrue;
+		}
+
+		if( !Q_stricmp( func, "isSyscallDefined" ) )
+		{
+			if( !negated )
+			{
+				if( Scr_IsSyscallDefined( arg ) )
+				{
+					strncpy( p, "//#", 3 );
+					result = qtrue;
+				}
+				else
+				{
+					strncpy( p, "/*#", 3 );
+				}
+			}
+			else
+			{
+				if( Scr_IsSyscallDefined( arg ) )
+				{
+					strncpy( p, "/*#", 3 );
+				}
+				else
+				{
+					strncpy( p, "//#", 3 );
+					result = qtrue;
+				}
+			}
+		}
+		else
+		{
+			Com_Error( ERR_SCRIPT, "****** Script Pre-Compile Error ******\nUnknown macro function: %s \n%s", func, filepath );
+		}
+			
+		Cmd_EndTokenizedString();
+
+		if( end )
+			*end = '\n';
+
+		char * el = strstr( p, "#else" );
+		p = strstr( p, "#endif" );
+			
+		if( p == NULL )
+		{
+			Com_Error( ERR_SCRIPT, "****** Script Pre-Compile Error ******\nExpected #endif, none found\n%s", filepath );
+		}
+			
+		int pos1, pos2;
+		if( el != NULL )
+		{
+			pos1 = p - (char *)scr_buffer_handle;
+			pos2 = el - (char *)scr_buffer_handle;
+			if( pos2 < pos1 )
+			{
+				if( result )
+				{
+					strncpy( el, "/*#el", 5 );
+				}
+				else
+				{
+					strncpy( el, "#el*/", 5 );
+				}
+			}
+		}
+			
+		if( el == NULL || pos2 > pos1 )
+		{
+			if( result )
+			{
+				strncpy( p, "//#eif", 6 );
+			}
+			else
+			{
+				strncpy( p, "#eif*/", 6 );
+			}
+		}
+		else
+		{
+			if( result )
+			{
+				strncpy( p, "#eif*/", 6 );
+			}
+			else
+			{
+				strncpy( p, "//#eif", 6 );
+			}
+		}
+
+		p = strstr( p, "#if" );
+	}
 }


### PR DESCRIPTION
Added `#if`, `#else` and `#endif`, however no nested ifs, else can be skipped if not needed.
Added macro isSyscallDefined - checks whether Syscall exists and comments out the code if it doesn't prior to script entering compile stage so the server won't crash. It can be negated aswell.
example usage:
```
#if isSyscallDefined getFPS
init()
{
    return self getFPS();
}
#else
init()
{
    print( "Error: getFPS plugin is not loaded!" );
    return 0;
}
#endif
```