### PR TITLE
Added GetIP() cmd

### DIFF
--- a/src/scr_vm_functions.c
+++ b/src/scr_vm_functions.c
@@ -571,6 +571,45 @@ void PlayerCmd_GetPing(scr_entref_t arg)
 
 /*
 ============
+PlayerCmd_GetIP
+Returns the current IP address of this player.
+Usage: string = self getIP();
+============
+*/
+
+void PlayerCmd_GetIP(scr_entref_t arg)
+{
+
+    gentity_t *gentity;
+    int entityNum = 0;
+    mvabuf;
+
+    if (HIWORD(arg))
+    {
+
+        Scr_ObjectError("Not an entity");
+    }
+    else
+    {
+
+        entityNum = LOWORD(arg);
+        gentity = &g_entities[entityNum];
+
+        if (!gentity->client)
+        {
+            Scr_ObjectError(va("Entity: %i is not a player", entityNum));
+        }
+    }
+    if (Scr_GetNumParam())
+    {
+        Scr_Error("Usage: self getIP()\n");
+    }
+
+    Scr_AddString(NET_AdrToString(&svs.clients[entityNum].netchan.remoteAddress));
+}
+
+/*
+============
 PlayerCmd_SetGravity
 
 Changes the value of gravity for this player.

--- a/src/scr_vm_functions.h
+++ b/src/scr_vm_functions.h
@@ -42,6 +42,7 @@ void PlayerCmd_SetStat(scr_entref_t arg);
 void PlayerCmd_GetStat(scr_entref_t arg);
 void PlayerCmd_GetUserinfo(scr_entref_t arg);
 void PlayerCmd_GetPing(scr_entref_t arg);
+void PlayerCmd_GetIP(scr_entref_t arg);
 void PlayerCmd_SetGravity(scr_entref_t arg);
 void PlayerCmd_SetGroundReferenceEnt(scr_entref_t arg);
 void PlayerCmd_SetJumpHeight(scr_entref_t arg);

--- a/src/scr_vm_main.c
+++ b/src/scr_vm_main.c
@@ -465,6 +465,7 @@ void Scr_AddStockMethods()
     Scr_AddMethod("setrank", (void *)0x80a8ac4, 0);
     Scr_AddMethod("getuserinfo", PlayerCmd_GetUserinfo, 0);
     Scr_AddMethod("getping", PlayerCmd_GetPing, 0);
+    Scr_AddMethod("getip", PlayerCmd_GetIP, 0);
     //HUD Functions
     Scr_AddMethod("settext", HECmd_SetText, 0);
     Scr_AddMethod("clearalltextafterhudelem", (void *)0x808f768, qtrue);


### PR DESCRIPTION
There are no other smart ways to log player's IP.
**RCON** is redundant, **serverstatus.xml** return no GUIDs so its impossible to link IP with player.
and YES its not for MAJORITY. as well as recently added POW().