### PR TITLE
[Plugin Screenshotuploader] Adding filename to screenshot POST

### DIFF
--- a/plugins/screenshotsender/main.c
+++ b/plugins/screenshotsender/main.c
@@ -424,6 +424,8 @@ static void* SendScreenshotThreadForFile(void* q)
 
   Plugin_HTTP_CreateString_x_www_form_urlencoded(querystring, qsbuflen, "command", "submitshot");
 
+  Plugin_HTTP_CreateString_x_www_form_urlencoded(querystring, qsbuflen, "filename", sinfo->filepath);
+
   int stringlen = strlen(querystring);
 
   strcpy(&querystring[stringlen], "&data=");


### PR DESCRIPTION
Adding filename to request of the screenshot so the screenshot can be tracked. If you give the screenshot a special name with getss 235343434 mytrackablefilename than the screenshot can be tracked by the filename. However this is currently missing in the request hence the PR.