### PR TITLE
Fixes bug in the GScr_Float function were negative float strings weren't converted to float

### DIFF
--- a/src/scr_vm_functions.c
+++ b/src/scr_vm_functions.c
@@ -3346,7 +3346,7 @@ void GScr_Float()
     {
         char* strFloat = Scr_GetString(0);
         double result = 0.0;
-        if (isdigit(strFloat[0]))
+        if ( isdigit(strFloat[0]) || (strFloat[0] == '-' && isdigit(strFloat[1])))
             result = atof(strFloat);
         Scr_AddFloat((float)result);
     }


### PR DESCRIPTION
### Description:

If you try to convert a negative string to float you will get 0. That's because you just check if the first character is a digit

### How to reproduce:
``` c
  println("==============");
  println("^1FLOAT TEST START:");
  string1 = "1";    float1 = float(string1);
  string2 = "1.1";  float2 = float(string2);
  string3 = "1.1f"; float3 = float(string3);
  string4 = "-1";   float4 = float(string4);
  string5 = "-1.1"; float5 = float(string5);
  string6 = "-1.1f";float6 = float(string6);
  println("String: " + string1 + "\tFloat:" + float1);
  println("String: " + string2 + "\tFloat:" + float2);
  println("String: " + string3 + "\tFloat:" + float3);
  println("String: " + string4 + "\tFloat:" + float4);
  println("String: " + string5 + "\tFloat:" + float5);
  println("String: " + string6 + "\tFloat:" + float6);
  println("^1FLOAT END ");
  println("==============");
```
### Results:
```
Debug: ==============
Debug: FLOAT TEST START:
Debug: String: 1        Float:1
Debug: String: 1.1      Float:1.1
Debug: String: 1.1f     Float:1.1
Debug: String: -1       Float:0
Debug: String: -1.1     Float:0
Debug: String: -1.1f    Float:0
Debug: FLOAT END
Debug: ==============
```
### Results after fix
```
Debug: ==============
Debug: FLOAT TEST START:
Debug: String: 1        Float:1
Debug: String: 1.1      Float:1.1
Debug: String: 1.1f     Float:1.1
Debug: String: -1       Float:-1
Debug: String: -1.1     Float:-1.1
Debug: String: -1.1f    Float:-1.1
Debug: FLOAT END
Debug: ==============
```

```