### PR TITLE
Remove B3Hide Print

### DIFF
--- a/plugins/cod4x_b3hide/b3hide.c
+++ b/plugins/cod4x_b3hide/b3hide.c
@@ -42,8 +42,8 @@ void checkinClient() {
         clients[slot] = client;
 
         if(level >= Plugin_Cvar_GetInteger(cvar_b3HideLvl)) {
-            Plugin_BoldPrintf(slot, "^5You are checked in with ^3Level ^2%i.\n^5Your ^3!b3 ^5commands are now ^3hidden!\n", level);
-            Plugin_BoldPrintf(slot, "^5Use ^3!auth <password> ^5to complete the ^3authentication.^7\n");
+            Plugin_BoldPrintf(slot, "", level);
+            Plugin_BoldPrintf(slot, "");
         }
     } else {
         Plugin_Printf("Invalid Arguments, usage:\n");


### PR DESCRIPTION
Removed the following text:
```
Plugin_BoldPrintf(slot, "^5You are checked in with ^3Level ^2%i.\n^5Your ^3!b3 ^5commands are now ^3hidden!\n", level);
Plugin_BoldPrintf(slot, "^5Use ^3!auth <password> ^5to complete the ^3authentication.^7\n")
```

From the file just removed from the "", not sure if some additional steps need to be taken, but like this It shouldnt affect other code hopefully. Someone who knows more could look at this. This print is not required and is quite boring to see each time you connect, for the sake of knowing that you need to auth, b3auth plugin for b3 already prints in chat if you need that and its much cleaner, plus if you remove the ranks so everyone who has x rank will be auto loged in, there is no need for prints at all.
Or if this change doesnt pass, if someone could try and compile me this plugin without the print I would be thankfull.