### PR TITLE
SetText fix

### DIFF
--- a/src/scr_vm_functions.c
+++ b/src/scr_vm_functions.c
@@ -2222,9 +2222,9 @@ void HECmd_SetText(scr_entref_t entnum)
 
     game_hudelem_t *element = &g_hudelems[entnum.entnum];
 
-    HudElem_ClearTypeSettings(element);
-
     int cs_index = element->elem.text;
+	
+    HudElem_ClearTypeSettings(element);
 
     /* Must be set to 0 before calling Scr_CanFreeLocalizedConfigString() */
     element->elem.text = 0;


### PR DESCRIPTION
Swapped two lines.
Couldn't free CS string because element's TypeSettings was cleared before saving cs_index.
This caused server crash.