### PR TITLE
Reintegrate fastfile extractor

### DIFF
--- a/src/db_load.cpp
+++ b/src/db_load.cpp
@@ -71,6 +71,7 @@
 #define XASSET_ENTRY_POOL_SIZE 32768
 
 extern "C" void PrintScriptStrings();
+extern "C" void store_fastfile_contents_information();
 
 struct XBlock
 {
@@ -1206,6 +1207,7 @@ void __cdecl DB_LoadXFileInternal()
   }
 
   DB_PopStreamPos();
+  store_fastfile_contents_information();
   Load_DelayStream();
 
   --g_loadingAssets;

--- a/src/xassets.h
+++ b/src/xassets.h
@@ -101,7 +101,7 @@ union XAssetHeader
   struct GfxLightDef *lightDef;
   struct Font_s *font;
   struct MenuList *menuList;
-  struct menuDef_t *menu;
+  struct MenuDef_t *menu;
   struct LocalizeEntry *localize;
   struct WeaponDef *weapon;
   struct SndDriverGlobals *sndDriverGlobals;

--- a/src/xassets/menulist.h
+++ b/src/xassets/menulist.h
@@ -14,5 +14,5 @@ struct MenuList
 {
   const char *name;
   int menuCount;
-  struct menuDef_t **menus;
+  struct MenuDef_t **menus;
 };


### PR DESCRIPTION
Updated the extractor code to be compatible with the current codebase.

Please check if `store_fastfile_contents_information` hook was placed in the right place since I couldn't find any symbols for the linux ded server so I had to make a little educated guess.