### PR TITLE
Don't save duplicates to console history

### DIFF
--- a/src/cmd_completion.c
+++ b/src/cmd_completion.c
@@ -43,6 +43,7 @@ Field_Clear
 */
 void Field_Clear( field_t *edit ) {
 	memset(edit->buffer, 0, MAX_EDIT_LINE);
+	edit->len = 0;
 	edit->cursor = 0;
 	edit->scroll = 0;
 }
@@ -150,11 +151,13 @@ static qboolean Field_Complete( void )
 	Q_strncpyz( &completionField->buffer[ completionOffset ], shortestMatch,
 		sizeof( completionField->buffer ) - completionOffset );
 
-	completionField->cursor = strlen( completionField->buffer );
+	completionField->len = strlen( completionField->buffer );
+	completionField->cursor = completionField->len;
 
 	if( matchCount == 1 )
 	{
 		Q_strncat( completionField->buffer, sizeof( completionField->buffer ), " " );
+		completionField->len++;
 		completionField->cursor++;
 		return qtrue;
 	}

--- a/src/cmd_completion.h
+++ b/src/cmd_completion.h
@@ -40,7 +40,7 @@ Edit fields and command line history/completion
 typedef struct {
 	int		cursor;
 	int		scroll;
-	int		widthInChars;
+	int		len;
 	char	buffer[MAX_EDIT_LINE];
 } field_t;
 

--- a/src/unix/sys_con_tty.c
+++ b/src/unix/sys_con_tty.c
@@ -69,6 +69,7 @@ static field_t ttyEditLines[ CON_HISTORY ];
 static int hist_current = -1, hist_count = 0;
 
 void Field_AutoComplete( field_t *field );
+field_t *Hist_Prev( void );
 
 
 #ifndef MAXPRINTMSG
@@ -204,6 +205,12 @@ void Hist_Add(field_t *field)
 	assert(hist_count >= 0);
 	assert(hist_current >= -1);
 	assert(hist_current <= hist_count);
+	if (hist_count > 0 && strcmp(field->buffer, ttyEditLines[0].buffer) == 0)
+	{
+		// Don't add duplicate entries to history (same as HISTCONTROL=ignoredups in bash)
+		hist_current = -1; // re-init
+		return;
+	}
 	// make some room
 	for (i=CON_HISTORY-1; i>0; i--)
 	{


### PR DESCRIPTION
When issuing same command over and over again, don't flood the history with useless duplicates. Instead, put the current command to history only if the previous command isn't the same.