### PR TITLE
Removed ambfix

### DIFF
--- a/src/db_load.cpp
+++ b/src/db_load.cpp
@@ -2103,12 +2103,7 @@ void DB_ReferencedFastFiles(char* g_zoneSumList, char* g_zoneNameList, int maxsi
 		Q_strncat(g_zoneNameList, maxsize, " usermaps/");
 		Q_strncat(g_zoneNameList, maxsize, zone->zoneinfo.name);
 		Q_strncat(g_zoneNameList, maxsize, "_load");
-
 	}
-	Com_sprintf(checkSum, sizeof(checkSum), " %u", 496286);
-	Q_strncat(g_zoneSumList, maxsize, checkSum);
-	Q_strncat(g_zoneNameList, maxsize, " cod4x_ambfix");
-
 }
 
 


### PR DESCRIPTION
The ambfix was removed from the client because it didn't work. This PR removes the remnant that was left on the server.