### PR TITLE
[DOS] Add check for negative realiable acknowledge

### DIFF
--- a/src/sv_main.c
+++ b/src/sv_main.c
@@ -1998,7 +1998,15 @@ __optimize3 __regparm2 void SV_PacketEvent( netadr_t *from, msg_t *msg ) {
         Com_Printf(CON_CHANNEL_SERVER,"Invalid reliableAcknowledge message from %s - reliableAcknowledge is %i\n", cl->name, cl->reliableAcknowledge);
         return;
     }
+
     cl->reliableAcknowledge = MSG_ReadLong( msg );
+
+    if (cl->reliableAcknowledge < 0)
+    {
+        Com_Printf(CON_CHANNEL_SERVER,"Negative reliableAcknowledge message from %s - reliableAcknowledge is %i\n", cl->name, cl->reliableAcknowledge);
+        cl->reliableAcknowledge = cl->reliableSequence;
+        return;
+    }
 
     if((cl->reliableSequence - cl->reliableAcknowledge) > (MAX_RELIABLE_COMMANDS - 1)){
         Com_Printf(CON_CHANNEL_SERVER,"Out of range reliableAcknowledge message from %s - reliableSequence is %i, reliableAcknowledge is %i\n",


### PR DESCRIPTION
A modified client can send an invalid packet that causes the server to get stuck for a long time in the loop inside the SV_UpdateServerCommandsToClient function; the server will then become unresponsive and causing all connected clients to drop. This is caused probably by the fact that reliable acknowledge is a signed integer and MSG_ReadLong also reads data as "int" from the data packet.

I have patched this bug on IW4, S1 and IW6 (for the xlabs clients) by adding a check shortly after reliable acknowledge is read from the inbound packet. I have quickly looked at the cod4x source code and I don't see any code that patches this bug.
My patch for this client is a bit different from the other ones I wrote but it should prevent the issue. Although I have confirmed the presence of the dos on all other cods from IW4 to S1 I didn't try on cod4 because I can safely assume this is an issue with all cod games. If any repo maintainer wants to confirm for themselves the presence of the dos on cod4 they can use my fully documented poc for IW5. The same code works on all other call of duty games I tested and if the bug is present, you should see the server thread consuming a lot of resources as it gets stuck in the loop.


Link to my patches for the other clients
- [IW6](https://github.com/XLabsProject/iw6x-client/pull/492/)
- [S1](https://github.com/XLabsProject/s1x-client/pull/265)
- [IW4](https://github.com/XLabsProject/iw4x-client/pull/129)

 

Here is the documented exploit﻿ code I wrote:
- [IW5](https://github.com/diamante0018/MW3ServerFreezer/blob/main/src/component/exploit.cpp)

PS
I came across this vulnerability for the first time when I discovered a thread on a popular cheating forum documenting a "server freezer", I know it might be counterproductive to link to a poc of the exploit before this issue is resolved but since the original thread has been around for other a year it shouldn't be a problem, also I didn't think about looking at the cod4x client to see if it's also a problem here until now.
