### PR TITLE
Removed unnecessary ban status check

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -800,7 +800,6 @@ void SV_InitGameProgs(int a1);
 
 //sv_banlist.c
 void SV_InitBanlist( void );
-void  SV_ReloadBanlist();
 char* SV_PlayerIsBanned(uint64_t playerid, uint64_t steamid, netadr_t *addr, const char* name, char* message, int len);
 char* SV_PlayerBannedByip(netadr_t *netadr, char* message, int len);	//Gets called in SV_DirectConnect
 void SV_PlayerAddBanByip(netadr_t *remote, char *message, int expire);

--- a/src/sv_banlist.c
+++ b/src/sv_banlist.c
@@ -202,13 +202,6 @@ char* SV_PlayerIsBanned(uint64_t playerid, uint64_t steamid, netadr_t *addr, con
   return NULL;
 }
 
-
-void SV_ReloadBanlist()
-{
-
-}
-
-
 void SV_InitBanlist()
 {
     ipbantime = Cvar_RegisterInt("banlist_maxipbantime", MAX_DEFAULT_IPBAN_MINUTES, 0, 20160, 0, "Limit of minutes to keep a ban against an ip-address up");

--- a/src/sv_main.c
+++ b/src/sv_main.c
@@ -3505,11 +3505,6 @@ qboolean SV_FFAPlayerCanBlock(){
 
 //Few custom added things which should happen if we load a new level or restart a level
 void SV_PreLevelLoad(){
-
-    client_t* client;
-    int i;
-    char buf[MAX_STRING_CHARS];
-
     Com_UpdateRealtime();
     time_t realtime = Com_GetRealtime();
     char *timestr = ctime(&realtime);
@@ -3527,29 +3522,9 @@ void SV_PreLevelLoad(){
 
     FS_ShutdownIwdPureCheckReferences();
 
-    SV_ReloadBanlist();
-
     NV_LoadConfig();
 
-    for ( client = svs.clients, i = 0 ; i < sv_maxclients->integer ; i++, client++ ) {
-
-        // send the new gamestate to all connected clients
-        if ( client->state < CS_ACTIVE ) {
-            continue;
-        }
-
-        if ( client->netchan.remoteAddress.type == NA_BOT ) {
-            continue;
-        }
-
-        if(SV_PlayerIsBanned(client->playerid, client->steamid, &client->netchan.remoteAddress, client->name, buf, sizeof(buf))){
-            SV_DropClient(client, "Prior kick/ban");
-            continue;
-        }
-    }
-
     HL2Rcon_EventLevelStart();
-
 }
 
 void SV_PostLevelLoad(){


### PR DESCRIPTION
The ban status is checked when the player connects and upon a new map load, all the players practically reconnect and the ban status is checked there. As such, the ban status check in `SV_PreLevelLoad()` is not necessary.