### PR TITLE
Bot action improvments

### DIFF
--- a/src/player.h
+++ b/src/player.h
@@ -51,7 +51,8 @@
 #define KEY_MASK_SMOKE          32768
 #define KEY_MASK_NIGHTVISION    262144
 #define KEY_MASK_ADS            524288
-#define KEY_MASK_USE            0x28 /* Combination */
+#define KEY_MASK_USE            8 
+#define KEY_MASK_USERELOAD      0x20
 #define BUTTON_ATTACK			KEY_MASK_FIRE
 
 typedef struct{

--- a/src/sv_bots.cpp
+++ b/src/sv_bots.cpp
@@ -29,8 +29,9 @@ const BotAction_t BotActions[] =
     { "sprint",     KEY_MASK_SPRINT     },
     { "leanleft",   KEY_MASK_LEANLEFT   },
     { "leanright",  KEY_MASK_LEANRIGHT  },
-    { "ads",        KEY_MASK_ADS_MODE   },
-    { "holdbreath", KEY_MASK_HOLDBREATH }
+    { "ads",        KEY_MASK_ADS_MODE | KEY_MASK_ADS },
+    { "holdbreath", KEY_MASK_HOLDBREATH },
+    { "activate",   KEY_MASK_USE }
 };
 /*
 ==================

--- a/src/sv_main.c
+++ b/src/sv_main.c
@@ -4061,7 +4061,7 @@ void SV_BotUserMove(client_t *client)
     }
 
     if (shouldSpamUseButton(ent))
-        ucmd.buttons |= KEY_MASK_USE;
+        ucmd.buttons |= KEY_MASK_USE | KEY_MASK_USERELOAD;
 
     client->deltaMessage = client->netchan.outgoingSequence - 1;
     SV_ClientThink(client, &ucmd);


### PR DESCRIPTION
Adds the 'activate' bot action, fixes the 'ads' bot action to allow bots to throw c4s.