### PR TITLE
Fix incorrect alignments when using ScaleOverTime

### DIFF
--- a/src/asmsource/_g_hudelem.asm
+++ b/src/asmsource/_g_hudelem.asm
@@ -42,6 +42,7 @@
 	extern Scr_AddClassField
 	extern Scr_SetString
 	extern HECmd_SetText
+	extern HECmd_ScaleOverTime
 
 ;Exports of g_hudelem:
 	global HECmd_ClearAllTextAfterHudElem
@@ -57,7 +58,6 @@
 	global HECmd_SetValue
 	global HECmd_SetWaypoint
 	global HECmd_FadeOverTime
-	global HECmd_ScaleOverTime
 	global HECmd_MoveOverTime
 	global HECmd_Reset
 	global HECmd_Destroy
@@ -578,97 +578,6 @@ HECmd_FadeOverTime_20:
 	mov dword [esp], 0x0
 	call Scr_ParamError
 	jmp HECmd_FadeOverTime_40
-
-
-;HECmd_ScaleOverTime(scr_entref_t)
-HECmd_ScaleOverTime:
-	push ebp
-	mov ebp, esp
-	push edi
-	push esi
-	push ebx
-	sub esp, 0x2c
-	mov eax, [ebp+0x8]
-	mov edx, eax
-	shr eax, 0x10
-	sub ax, 0x1
-	jz HECmd_ScaleOverTime_10
-	mov dword [esp], _cstring_not_a_hud_elemen
-	call Scr_ObjectError
-	xor edi, edi
-HECmd_ScaleOverTime_60:
-	call Scr_GetNumParam
-	cmp eax, 0x3
-	jz HECmd_ScaleOverTime_20
-	mov dword [esp], _cstring_hudelem_scaleove
-	call Scr_Error
-HECmd_ScaleOverTime_20:
-	mov dword [esp], 0x0
-	call Scr_GetFloat
-	fstp dword [ebp-0x1c]
-	movss xmm0, dword [ebp-0x1c]
-	ucomiss xmm0, [_float_0_00000000]
-	jbe HECmd_ScaleOverTime_30
-HECmd_ScaleOverTime_70:
-	ucomiss xmm0, [_float_60_00000000]
-	ja HECmd_ScaleOverTime_40
-HECmd_ScaleOverTime_50:
-	mov dword [esp], 0x1
-	call Scr_GetInt
-	mov esi, eax
-	mov dword [esp], 0x2
-	call Scr_GetInt
-	mov ebx, eax
-	mov eax, level
-	mov eax, [eax+0x1ec]
-	mov [edi+0x50], eax
-	movss xmm0, dword [ebp-0x1c]
-	mulss xmm0, [_float_1000_00000000]
-	movss [ebp-0x1c], xmm0
-	addss xmm0, [_float_0_50000000]
-	movss [esp], xmm0
-	call floorf
-	fstp dword [ebp-0x20]
-	cvttss2si eax, [ebp-0x20]
-	mov [edi+0x54], eax
-	mov eax, [edi+0x38]
-	mov [edi+0x48], eax
-	mov eax, [edi+0x3c]
-	mov [edi+0x4c], eax
-	mov [edi+0x38], esi
-	mov [edi+0x3c], ebx
-	add esp, 0x2c
-	pop ebx
-	pop esi
-	pop edi
-	pop ebp
-	ret
-HECmd_ScaleOverTime_40:
-	cvtss2sd xmm0, xmm0
-	movsd [esp+0x4], xmm0
-	mov dword [esp], _cstring_scale_time_g__60
-	call va
-	mov [esp+0x4], eax
-	mov dword [esp], 0x0
-	call Scr_ParamError
-	jmp HECmd_ScaleOverTime_50
-HECmd_ScaleOverTime_10:
-	movzx edx, dx
-	lea eax, [edx+edx*4]
-	lea eax, [edx+eax*4]
-	lea eax, [edx+eax*2]
-	lea edi, [eax*4+g_hudelems]
-	jmp HECmd_ScaleOverTime_60
-HECmd_ScaleOverTime_30:
-	jp HECmd_ScaleOverTime_70
-	cvtss2sd xmm0, xmm0
-	movsd [esp+0x4], xmm0
-	mov dword [esp], _cstring_scale_time_g__0
-	call va
-	mov [esp+0x4], eax
-	mov dword [esp], 0x0
-	call Scr_ParamError
-	jmp HECmd_ScaleOverTime_50
 
 
 ;HECmd_MoveOverTime(scr_entref_t)

--- a/src/scr_vm_functions.c
+++ b/src/scr_vm_functions.c
@@ -2238,6 +2238,52 @@ void HECmd_SetText(scr_entref_t entnum)
     element->elem.text = G_LocalizedStringIndex(buffer);
 }
 
+void HECmd_ScaleOverTime(scr_entref_t hud_elem_num)
+{
+    game_hudelem_t *hudelem_t = NULL;
+    if (hud_elem_num.classnum == 1)
+    {
+        hudelem_t = &g_hudelems[hud_elem_num.entnum];
+    }
+    else
+    {
+        Scr_ObjectError("not a hud element");
+        hudelem_t = 0;
+    }
+
+    if (Scr_GetNumParam() != 3)
+    {
+        Scr_Error("hudelem scaleOverTime(time_in_seconds, new_width, new_height)");
+    }
+
+    float time = Scr_GetFloat(0);
+    if (time <= 0.0)
+    {
+        Scr_ParamError(0, va("scale time %g <= 0", time));
+    }
+    else if (time > 60.0)
+    {
+        Scr_ParamError(0, va("scale time %g > 60", time));
+    }
+
+    int newWidth = Scr_GetInt(1u);
+    int newHeight = Scr_GetInt(2u);
+
+    extern level_locals_t level;
+    hudelem_t->elem.scaleStartTime = level.time;
+    int roundedTimeMs = floorf((float)(time * 1000.0) + 0.5);
+    hudelem_t->elem.scaleTime = roundedTimeMs;
+    hudelem_t->elem.fromWidth = hudelem_t->elem.width;
+    hudelem_t->elem.fromHeight = hudelem_t->elem.height;
+    hudelem_t->elem.width = newWidth;
+    hudelem_t->elem.height = newHeight;
+
+    // Bug fix: it doesn't contain the correct value of the hudelem so needs to be overwritten
+    // otherwise.. you get a 'jumpy' scaleovertime
+    hudelem_t->elem.fromAlignOrg = hudelem_t->elem.alignOrg;
+    hudelem_t->elem.fromAlignScreen = hudelem_t->elem.alignScreen;
+}
+
 void GScr_MakeCvarServerInfo(void)
 {
     const char *var_name;

--- a/src/scr_vm_functions.h
+++ b/src/scr_vm_functions.h
@@ -96,6 +96,7 @@ void PlayerCmd_spawn(scr_entref_t arg);
 void GScr_NewHudElem();
 void GScr_NewClientHudElem();
 void HECmd_SetText(scr_entref_t entnum);
+void HECmd_ScaleOverTime(scr_entref_t hud_elem_num);
 void GScr_Spawn();
 void GScr_SpawnVehicle();
 void GScr_SpawnHelicopter();


### PR DESCRIPTION
When you have "smooth" progress bars, such as here: https://github.com/opencj-dev/server-gsc/blob/master/opencj/progressbar.gsc#L89
..in combination with "fullscreen" alignment: https://github.com/opencj-dev/server-gsc/blob/master/opencj/progressbar.gsc#L42

Then with the existing functionality of HECmd_ScaleOverTime this has buggy behavior where it first decreases the width and then it starts increasing it again. In CoD2 this behavior does not occur. In CoD4 HECmd_MoveOverTime the behavior does not occur.

The fix is to copy over the origin and screen alignment.

- IzNoGod
- Yocairo