### PR TITLE
Fix potential OOB access during huffman decompression

### DIFF
--- a/src/huffman.c
+++ b/src/huffman.c
@@ -50,9 +50,9 @@ static int get_bit( byte *fin ) {
 
 /* Get a symbol */
 
-static void Huff_offsetReceive( node_t *node, int *ch, byte *fin, int *offset ) {
+static void Huff_offsetReceive( node_t *node, int *ch, byte *fin, int readsize, int *offset ) {
 	bloc = *offset;
-	while ( node && node->symbol == INTERNAL_NODE ) {
+	while ( node && node->symbol == INTERNAL_NODE && bloc < readsize ) {
 
 		if ( get_bit( fin ) ) {
 			node = node->right;
@@ -128,7 +128,7 @@ int MSG_ReadBitsCompress(const byte* input, int readsize, byte* outputBuf, int o
     }
 
     for(offset = 0, i = 0; offset < readsize && i < outputBufSize; i++){
-        Huff_offsetReceive( msgHuff.tree, &get, (byte*)input, &offset);
+        Huff_offsetReceive( msgHuff.tree, &get, (byte*)input, readsize, &offset);
         *outptr = (byte)get;
         outptr++;
     }


### PR DESCRIPTION
If 'readsize' is equal to the size of the input buffer, there's potentially OOB access because the while loop increases the bit offset and only checks the nodes from the huffman tree and not whether the number of bits exceeds 'readsize'. This won't lead to problems if the size of input buffer is greater than 'readsize' but still a design flaw.