### PR TITLE
Use playerid in demo name. Fixes #401

### DIFF
--- a/src/sv_client.c
+++ b/src/sv_client.c
@@ -1209,7 +1209,7 @@ void SV_ClientEnterWorld( client_t *client, usercmd_t *cmd ) {
 	// call the game begin function
 	ClientBegin( clientNum );
 
-	SV_SApiSteamIDToString(client->steamid, psti, sizeof(psti));
+	SV_SApiSteamIDToString(client->playerid, psti, sizeof(psti));
 
 	//It was never intended to make a new demo for each fast_restart.
 	//SV_SpawnServer() stops the demo and cleans the name which did not happen here which resulted in strange naming bug

--- a/src/sv_client.c
+++ b/src/sv_client.c
@@ -1209,7 +1209,7 @@ void SV_ClientEnterWorld( client_t *client, usercmd_t *cmd ) {
 	// call the game begin function
 	ClientBegin( clientNum );
 
-	SV_SApiSteamIDToString(client->playerid, psti, sizeof(psti));
+	SV_SApiSteamIDToString(client->playerid ? client->playerid : client->steamid, psti, sizeof(psti));
 
 	//It was never intended to make a new demo for each fast_restart.
 	//SV_SpawnServer() stops the demo and cleans the name which did not happen here which resulted in strange naming bug


### PR DESCRIPTION
This PR updates the auto record feature to use the playerid instead of steamid in demos automatically recorded using `sv_autodemorecord` variable. The Steam ID is not always populated and, therefore, the playerid should be considered a more reliable identifier to use in demo names.