### PR TITLE
Win32: Console

### DIFF
--- a/makefile
+++ b/makefile
@@ -53,7 +53,7 @@ else
 DCFLAGS=-fno-pie -O1 -DNDEBUG
 endif
 
-WIN_LFLAGS=-m32 -g -Wl,--nxcompat,--stack,0x800000 -mwindows -static-libgcc -static -lm
+WIN_LFLAGS=-m32 -g -Wl,--nxcompat,--stack,0x800000 -static-libgcc -static -lm
 WIN_LLIBS=tomcrypt mbedtls mbedcrypto mbedx509 ws2_32 wsock32 iphlpapi gdi32 winmm crypt32 stdc++
 LINUX_LFLAGS=-m32 -g -static-libgcc -rdynamic -Wl,-rpath=./
 LINUX_LLIBS=tomcrypt mbedtls mbedcrypto mbedx509 dl pthread m stdc++
@@ -168,7 +168,7 @@ gittagging:
 ifneq ($(OS),Windows_NT)
 	git tag -a v$(VERSION)
 	git push origin --tags
-endif	
+endif
 
 #################################
 # A rule to make mbedtls library.
@@ -284,7 +284,7 @@ clean_all:
 docker: $(TARGET)
 	@docker build . -t cod4x/bleeding
 
-plugins: 
+plugins:
 	@$(MAKE) -C $(PLUGIN_DIR)/screenshotsender
 	#@$(MAKE) -C $(PLUGIN_DIR)/antispam
 	@$(MAKE) -C $(PLUGIN_DIR)/censor

--- a/src/common.c
+++ b/src/common.c
@@ -401,9 +401,6 @@ Returns last event time
 */
 void Com_EventLoop( void ) {
 	sysEvent_t	*ev;
-#ifdef _WIN32
-	char consoleline[1024];
-#endif
 
 	while ( 1 ) {
 		ev = Com_GetSystemEvent();
@@ -415,11 +412,7 @@ void Com_EventLoop( void ) {
 			switch(ev->evType)
 			{
 				case SE_CONSOLE:
-#ifdef _WIN32
-          Com_sprintf(consoleline, sizeof(consoleline), "]%s", (char *)ev->evPtr);
-          Sys_Print(consoleline);
-#endif
-        	Cbuf_AddText( (char *)ev->evPtr );
+        			Cbuf_AddText( (char *)ev->evPtr );
 					Cbuf_AddText("\n");
 				break;
 				default:

--- a/src/sec_update.c
+++ b/src/sec_update.c
@@ -881,9 +881,6 @@ void Sec_Update( qboolean getbasefiles ){
 	{
 		Com_PrintError(CON_CHANNEL_SYSTEM,"Update has failed. Trying to recover...\n");
 		Sec_UndoBackup(files.next);
-
-//		MessageBoxA(NULL, "Couldn't install update", "Couldn't install update", MB_OK);
-		
 		Sec_AutoupdateUnlock(lockfile);
 		Com_Quit_f();
 		return;

--- a/src/win32/sys_win32.h
+++ b/src/win32/sys_win32.h
@@ -51,7 +51,7 @@ unsigned sysMsgTime;
 qboolean windowsCreated;
 } WinVars_t;
 
-void CON_Show( int visLevel, qboolean quitOnClose );
+void CON_Show(void);
 char** PE32_GetStrTable(void *buff, int len, sharedlib_data_t *text);
 
 extern WinVars_t g_wv;


### PR DESCRIPTION
https://github.com/callofduty4x/CoD4x_Server/issues/250 Removed the windows GUI with the equivalent of the linux console (ANSI colors, history, auto completion).

![image](https://user-images.githubusercontent.com/26555415/223539306-b5055848-2a58-4d13-ac52-4b28bc3276e5.png)

The cvar ``ttycon_ansiColor`` can be used to turn on terminal colors if your terminal supports ANSI escape codes. (Git Bash / Windows Terminal). On by default if the terminal has the ``ENABLE_VIRTUAL_TERMINAL_PROCESSING`` flag set.