### PR TITLE
Fix bots with switchtoweapon and setspawnweapon builtins

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
       run: |
         cd C:/
         Start-BitsTransfer -Source https://downloads.sourceforge.net/mingw-w64/i686-8.1.0-release-posix-dwarf-rt_v6-rev0.7z -Destination mingw32.7z
-        7z x mingw32.7z
+        7z x -y mingw32.7z
         
     - name: Get NASM
       uses: ilammy/setup-nasm@v1  
@@ -90,8 +90,8 @@ jobs:
     - name: Get pexports
       run: |
         Invoke-WebRequest "https://github.com/callofduty4x/CoD4x_Server/raw/master/tools/pexports-0.47-mingw32-bin.tar.xz" -OutFile "pexports.tar.xz" 
-        7z x pexports.tar.xz 
-        7z x pexports.tar
+        7z x -y pexports.tar.xz 
+        7z x -y pexports.tar
         
     - name: Build
       run: | 
@@ -134,7 +134,7 @@ jobs:
         Copy-Item -Path sourcebansplugin/sourcebansplugin.dll -Destination plugins/
         Copy-Item -Path warn/warn.dll -Destination plugins/
         Copy-Item -Path legacybanlist/legacybanlist.dll -Destination plugins/
-        7z a plugins_windows.zip plugins/*
+        7z a -y plugins_windows.zip plugins/*
         cd ../
         
     - name: Publish release

--- a/src/asmsource/_g_weapon.asm
+++ b/src/asmsource/_g_weapon.asm
@@ -53,6 +53,7 @@
 	extern G_FireRocket
 	extern G_AntiLagRewindClientPos
 	extern G_AntiLag_RestoreClientPos
+	extern Bot_SetBotWeapon
 
 ;Exports of g_weapon:
 	global _ZZ11Melee_TraceP9gentity_sP11weaponParmsifffP7trace_tPfE12traceOffsets
@@ -1090,6 +1091,11 @@ G_SelectWeaponIndex:
 	mov eax, [ebp+0x8]
 	mov [esp], eax
 	call SV_GameSendServerCommand
+	mov eax, [ebp+0xc]
+	push eax
+	mov eax, [ebp+0x8]
+	push eax
+	call Bot_SetBotWeapon
 	leave
 	ret
 

--- a/src/sv_bots.cpp
+++ b/src/sv_bots.cpp
@@ -393,4 +393,13 @@ qboolean shouldSpamUseButton(gentity_t *bot)
     return is_alive == qfalse && ai->useSpamDelay == 0 ? qtrue : qfalse;
 }
 
+void Bot_SetBotWeapon(int clientNum, unsigned int weaponIdx)
+{
+    ::byte weapInt;
+
+    weapInt = static_cast<::byte>(weaponIdx);
+
+    g_botai[clientNum].weapon = weapInt;
+}
+
 }

--- a/src/sv_bots.cpp
+++ b/src/sv_bots.cpp
@@ -395,11 +395,7 @@ qboolean shouldSpamUseButton(gentity_t *bot)
 
 void Bot_SetBotWeapon(int clientNum, unsigned int weaponIdx)
 {
-    ::byte weapInt;
-
-    weapInt = static_cast<::byte>(weaponIdx);
-
-    g_botai[clientNum].weapon = weapInt;
+    g_botai[clientNum].weapon = static_cast<::byte>(weaponIdx);
 }
 
 }

--- a/src/sv_bots.h
+++ b/src/sv_bots.h
@@ -37,6 +37,7 @@ extern "C"
 
 void Scr_AddBotsMovement();
 qboolean shouldSpamUseButton(gentity_t *bot);
+void Bot_SetBotWeapon(int, unsigned int);
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
Allows for testclients to use proper weapons when the gsc builtins switchtoweapon and setspawnweapon are called,  required change for Bot Warfare to function properly 